### PR TITLE
Refactor: Optimizing Point Log Lookup Queries

### DIFF
--- a/src/main/java/com/gdg/Todak/point/controller/PointController.java
+++ b/src/main/java/com/gdg/Todak/point/controller/PointController.java
@@ -3,20 +3,12 @@ package com.gdg.Todak.point.controller;
 import com.gdg.Todak.common.domain.ApiResponse;
 import com.gdg.Todak.member.domain.AuthenticateUser;
 import com.gdg.Todak.member.resolver.Login;
-import com.gdg.Todak.point.dto.PointLogResponse;
 import com.gdg.Todak.point.dto.PointResponse;
-import com.gdg.Todak.point.service.PointLogService;
 import com.gdg.Todak.point.service.PointService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.Parameters;
-import io.swagger.v3.oas.annotations.enums.ParameterIn;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -27,21 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/points")
 public class PointController {
 
-    private final PointLogService pointLogService;
     private final PointService pointService;
-
-    @Operation(summary = "포인트 로그 조회", description = "로그인한 사용자의 포인트 로그를 조회하여 리스트형태로 받습니다.")
-    @GetMapping("/log")
-    @Parameters({
-            @Parameter(in = ParameterIn.QUERY, name = "page", description = "페이지 번호 (0부터 시작)", example = "0", schema = @Schema(type = "integer", defaultValue = "0")),
-            @Parameter(in = ParameterIn.QUERY, name = "size", description = "페이지 크기", example = "10", schema = @Schema(type = "integer", defaultValue = "10")),
-            @Parameter(in = ParameterIn.QUERY, name = "sort", description = "정렬 기준 (속성,오름차순|내림차순)", example = "createdAt,desc", schema = @Schema(type = "string"))
-    })
-    public ApiResponse<Page<PointLogResponse>> getPointLog(@Parameter(hidden = true) @Login AuthenticateUser authenticateUser,
-                                                           @Parameter(hidden = true) @PageableDefault Pageable pageable) {
-        Page<PointLogResponse> pointLogResponses = pointLogService.getPointLogList(authenticateUser.getUserId(), pageable);
-        return ApiResponse.ok(pointLogResponses);
-    }
 
     @Operation(summary = "포인트 조회", description = "로그인한 사용자의 포인트를 조회합니다.")
     @GetMapping

--- a/src/main/java/com/gdg/Todak/point/controller/PointLogController.java
+++ b/src/main/java/com/gdg/Todak/point/controller/PointLogController.java
@@ -1,0 +1,47 @@
+package com.gdg.Todak.point.controller;
+
+import com.gdg.Todak.common.domain.ApiResponse;
+import com.gdg.Todak.member.domain.AuthenticateUser;
+import com.gdg.Todak.member.resolver.Login;
+import com.gdg.Todak.point.dto.PointLogResponse;
+import com.gdg.Todak.point.dto.PointLogSearchRequest;
+import com.gdg.Todak.point.service.PointLogService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "포인트 로그 조회", description = "포인트 로그 조회 관련 API")
+@RequestMapping("/api/v1/points/logs")
+public class PointLogController {
+
+    private final PointLogService pointLogService;
+
+    @Operation(summary = "포인트 로그 조회", description = "로그인한 사용자의 포인트 로그를 조회하여 리스트형태로 받습니다.")
+    @GetMapping
+    @Parameters({
+            @Parameter(in = ParameterIn.QUERY, name = "page", description = "페이지 번호 (0부터 시작)", example = "0", schema = @Schema(type = "integer", defaultValue = "0")),
+            @Parameter(in = ParameterIn.QUERY, name = "size", description = "페이지 크기", example = "10", schema = @Schema(type = "integer", defaultValue = "10")),
+            @Parameter(in = ParameterIn.QUERY, name = "sort", description = "정렬 기준 (속성,오름차순|내림차순)", example = "createdAt,desc", schema = @Schema(type = "string"))
+    })
+    public ApiResponse<Page<PointLogResponse>> getPointLog(
+            @Parameter(hidden = true) @Login AuthenticateUser authenticateUser,
+            @ModelAttribute PointLogSearchRequest request,
+            @Parameter(hidden = true) @PageableDefault Pageable pageable
+    ) {
+        Page<PointLogResponse> pointLogResponses = pointLogService.getPointLogList(authenticateUser.getUserId(), request, pageable);
+        return ApiResponse.ok(pointLogResponses);
+    }
+}

--- a/src/main/java/com/gdg/Todak/point/dto/PointLogSearchRequest.java
+++ b/src/main/java/com/gdg/Todak/point/dto/PointLogSearchRequest.java
@@ -1,0 +1,15 @@
+package com.gdg.Todak.point.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+public class PointLogSearchRequest {
+    private String pointType;
+    private String pointStatus;
+    private LocalDate startDate;
+    private LocalDate endDate;
+}

--- a/src/main/java/com/gdg/Todak/point/repository/PointLogRepository.java
+++ b/src/main/java/com/gdg/Todak/point/repository/PointLogRepository.java
@@ -6,6 +6,7 @@ import com.gdg.Todak.point.PointType;
 import com.gdg.Todak.point.entity.PointLog;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -27,4 +28,6 @@ public interface PointLogRepository extends JpaRepository<PointLog, Long> {
     List<PointLog> findAllByPointStatus(PointStatus pointStatus);
 
     List<PointLog> findAllByCreatedAtBetween(Instant start, Instant end);
+
+    Page<PointLog> findAll(Specification<PointLog> spec, Pageable pageable);
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #-

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.(이미지 첨부 가능)
- 여러 파라미터 기반 포인트 조회 기능 추가
- MySQL EXPLAIN 분석을 통해 복합 조건 쿼리에서 적절한 인덱스가 없어 Full Table Scan이 발생함을 확인
- 실제 쿼리 패턴 분석을 통해 (user_id, point_type, point_status, created_at) 복합 인덱스 설계
  - (member_id, point_type, point_status, created_at) 복합 인덱스 추가
      - **처리 시간**: 220ms → 24ms로 단축 **(89.09% 성능 개선)**
      - **Query Cost**: 4,745.70 → 1.61로 감소 **(99.97% 비용 절감)**
      - **스캔 행 수**: 996,510행 → 3행으로 대폭 감소 **(99.99% 효율성 향상)**

### 스크린샷 (선택)
Before
<img width="337" height="386" alt="image" src="https://github.com/user-attachments/assets/4e2cc541-fb63-4dc0-92ed-f80a368e79e8" />
After
<img width="358" height="403" alt="image" src="https://github.com/user-attachments/assets/fd6e784c-4a3c-4499-a337-092f96cf6a4b" />

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> 성능 최적화를 위한 추가적인 인덱스 전략이 있으시다면 검토 후 구현에 반영하도록 하겠습니다.


## ⏰ 현재 버그
-

## ✏ Git Close
> close #-
