### PR TITLE
Refactor: Apply Facade pattern and introduce event-driven asynchronous processing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,7 @@ dependencies {
     implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.7.0'
     implementation 'net.javacrumbs.shedlock:shedlock-spring:5.1.0'
     implementation 'net.javacrumbs.shedlock:shedlock-provider-jdbc-template:5.1.0'
+    implementation 'org.springframework.retry:spring-retry'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/gdg/Todak/common/lock/LockExecutor.java
+++ b/src/main/java/com/gdg/Todak/common/lock/LockExecutor.java
@@ -1,0 +1,27 @@
+package com.gdg.Todak.common.lock;
+
+import com.gdg.Todak.member.domain.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.locks.Lock;
+
+@RequiredArgsConstructor
+@Component
+public class LockExecutor {
+
+    private final LockWithMemberFactory lockWithMemberFactory;
+
+    public void executeWithLock(String lockPrefix, Member member, Runnable runnable) {
+        String lockKey = lockPrefix + member.getId();
+        Lock lock = null;
+        try {
+            lock = lockWithMemberFactory.tryLock(member, lockKey, 10, 2);
+            runnable.run();
+        } finally {
+            if (lock != null) {
+                lockWithMemberFactory.unlock(member, lock);
+            }
+        }
+    }
+}

--- a/src/main/java/com/gdg/Todak/diary/controller/CommentController.java
+++ b/src/main/java/com/gdg/Todak/diary/controller/CommentController.java
@@ -3,6 +3,7 @@ package com.gdg.Todak.diary.controller;
 import com.gdg.Todak.common.domain.ApiResponse;
 import com.gdg.Todak.diary.dto.CommentRequest;
 import com.gdg.Todak.diary.dto.CommentResponse;
+import com.gdg.Todak.diary.facade.CommentFacade;
 import com.gdg.Todak.diary.service.CommentService;
 import com.gdg.Todak.member.domain.AuthenticateUser;
 import com.gdg.Todak.member.resolver.Login;
@@ -26,6 +27,7 @@ import org.springframework.web.bind.annotation.*;
 public class CommentController {
 
     private final CommentService commentService;
+    private final CommentFacade commentFacade;
 
     @GetMapping("/{diaryId}")
     @Operation(summary = "댓글 조회", description = "특정 게시글의 댓글 페이지네이션 조회, 본인 또는 친구의 일기의 댓글만 조회 가능. 댓글은 기본적으로 익명으로 표시됩니다.")
@@ -46,7 +48,7 @@ public class CommentController {
     @ResponseStatus(HttpStatus.CREATED)
     public ApiResponse<Void> saveComment(@RequestBody CommentRequest commentRequest, @PathVariable("diaryId") Long diaryId,
                                          @Parameter(hidden = true) @Login AuthenticateUser authenticateUser) {
-        commentService.saveComment(authenticateUser.getUserId(), diaryId, commentRequest);
+        commentFacade.saveComment(authenticateUser.getUserId(), diaryId, commentRequest);
         return ApiResponse.of(HttpStatus.OK, "저장되었습니다.");
     }
 

--- a/src/main/java/com/gdg/Todak/diary/controller/DiaryController.java
+++ b/src/main/java/com/gdg/Todak/diary/controller/DiaryController.java
@@ -2,6 +2,7 @@ package com.gdg.Todak.diary.controller;
 
 import com.gdg.Todak.common.domain.ApiResponse;
 import com.gdg.Todak.diary.dto.*;
+import com.gdg.Todak.diary.facade.DiaryFacade;
 import com.gdg.Todak.diary.service.DiaryService;
 import com.gdg.Todak.member.domain.AuthenticateUser;
 import com.gdg.Todak.member.resolver.Login;
@@ -20,13 +21,14 @@ import java.util.List;
 @Tag(name = "일기", description = "일기 관련 API")
 public class DiaryController {
 
+    private final DiaryFacade diaryFacade;
     private final DiaryService diaryService;
 
     @PostMapping
     @Operation(summary = "일기 작성 / 감정 등록", description = "일기를 작성한다. 감정만 등록하기도 가능. 감정은 HAPPY, SAD, ANGRY, EXCITED, NEUTRAL")
     @ResponseStatus(HttpStatus.CREATED)
     public ApiResponse<Void> writeDiary(@Parameter(hidden = true) @Login AuthenticateUser authenticateUser, @RequestBody DiaryRequest diaryRequest) {
-        diaryService.writeDiary(authenticateUser.getUserId(), diaryRequest);
+        diaryFacade.writeDiary(authenticateUser.getUserId(), diaryRequest);
         return ApiResponse.of(HttpStatus.CREATED, "작성되었습니다.");
     }
 

--- a/src/main/java/com/gdg/Todak/diary/dto/SaveCommentDto.java
+++ b/src/main/java/com/gdg/Todak/diary/dto/SaveCommentDto.java
@@ -1,0 +1,26 @@
+package com.gdg.Todak.diary.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.Instant;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class SaveCommentDto {
+    private String senderId;
+    private String receiverId;
+    private Long diaryId;
+    private Instant createdAt;
+
+    public static SaveCommentDto of(String senderId, String receiverId, Long diaryId, Instant createdAt) {
+        return SaveCommentDto.builder()
+                .senderId(senderId)
+                .receiverId(receiverId)
+                .diaryId(diaryId)
+                .createdAt(createdAt)
+                .build();
+    }
+}

--- a/src/main/java/com/gdg/Todak/diary/facade/CommentFacade.java
+++ b/src/main/java/com/gdg/Todak/diary/facade/CommentFacade.java
@@ -1,0 +1,41 @@
+package com.gdg.Todak.diary.facade;
+
+import com.gdg.Todak.diary.dto.CommentRequest;
+import com.gdg.Todak.diary.entity.Comment;
+import com.gdg.Todak.diary.service.CommentService;
+import com.gdg.Todak.notification.dto.PublishNotificationRequest;
+import com.gdg.Todak.point.PointType;
+import com.gdg.Todak.point.dto.PointRequest;
+import com.gdg.Todak.point.service.PointService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Component
+public class CommentFacade {
+
+    private final CommentService commentService;
+    private final PointService pointService;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Transactional
+    public void saveComment(String userId, Long diaryId, CommentRequest request) {
+        // 1. 댓글 저장
+        Comment comment = commentService.saveComment(userId, diaryId, request);
+
+        // 2. 포인트 적립
+        pointService.earnPointByType(new PointRequest(comment.getMember(), PointType.COMMENT));
+
+        // 3. 알림 이벤트 발행
+        PublishNotificationRequest notificationRequest = PublishNotificationRequest.of(
+                userId,
+                comment.getDiary().getMember().getUserId(),
+                "comment",
+                comment.getDiary().getId(),
+                comment.getDiary().getCreatedAt()
+        );
+        eventPublisher.publishEvent(notificationRequest);
+    }
+}

--- a/src/main/java/com/gdg/Todak/diary/facade/CommentFacade.java
+++ b/src/main/java/com/gdg/Todak/diary/facade/CommentFacade.java
@@ -3,10 +3,7 @@ package com.gdg.Todak.diary.facade;
 import com.gdg.Todak.diary.dto.CommentRequest;
 import com.gdg.Todak.diary.entity.Comment;
 import com.gdg.Todak.diary.service.CommentService;
-import com.gdg.Todak.notification.dto.PublishNotificationRequest;
-import com.gdg.Todak.point.PointType;
-import com.gdg.Todak.point.dto.PointRequest;
-import com.gdg.Todak.point.service.PointService;
+import com.gdg.Todak.event.event.NewCommentEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
@@ -17,29 +14,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class CommentFacade {
 
     private final CommentService commentService;
-    private final PointService pointService;
     private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public void saveComment(String userId, Long diaryId, CommentRequest request) {
-        // 1. 댓글 저장
         Comment comment = commentService.saveComment(userId, diaryId, request);
-
-        // 2. 포인트 적립
-        pointService.earnPointByType(new PointRequest(comment.getMember(), PointType.COMMENT));
-
-        // 3. 알림 이벤트 발행
-        publishNotification(userId, comment);
-    }
-
-    private void publishNotification(String userId, Comment comment) {
-        PublishNotificationRequest notificationRequest = PublishNotificationRequest.of(
-                userId,
-                comment.getDiary().getMember().getUserId(),
-                "comment",
-                comment.getDiary().getId(),
-                comment.getDiary().getCreatedAt()
-        );
-        eventPublisher.publishEvent(notificationRequest);
+        eventPublisher.publishEvent(NewCommentEvent.of(comment));
     }
 }

--- a/src/main/java/com/gdg/Todak/diary/facade/CommentFacade.java
+++ b/src/main/java/com/gdg/Todak/diary/facade/CommentFacade.java
@@ -29,6 +29,10 @@ public class CommentFacade {
         pointService.earnPointByType(new PointRequest(comment.getMember(), PointType.COMMENT));
 
         // 3. 알림 이벤트 발행
+        publishNotification(userId, comment);
+    }
+
+    private void publishNotification(String userId, Comment comment) {
         PublishNotificationRequest notificationRequest = PublishNotificationRequest.of(
                 userId,
                 comment.getDiary().getMember().getUserId(),

--- a/src/main/java/com/gdg/Todak/diary/facade/DiaryFacade.java
+++ b/src/main/java/com/gdg/Todak/diary/facade/DiaryFacade.java
@@ -1,0 +1,68 @@
+package com.gdg.Todak.diary.facade;
+
+import com.gdg.Todak.diary.dto.DiaryRequest;
+import com.gdg.Todak.diary.entity.Diary;
+import com.gdg.Todak.diary.service.DiaryService;
+import com.gdg.Todak.diary.service.SchedulerService;
+import com.gdg.Todak.friend.FriendStatus;
+import com.gdg.Todak.friend.entity.Friend;
+import com.gdg.Todak.friend.repository.FriendRepository;
+import com.gdg.Todak.member.domain.Member;
+import com.gdg.Todak.notification.dto.PublishNotificationRequest;
+import com.gdg.Todak.point.PointType;
+import com.gdg.Todak.point.dto.PointRequest;
+import com.gdg.Todak.point.service.PointService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Component
+public class DiaryFacade {
+
+    private final DiaryService diaryService;
+    private final PointService pointService;
+    private final SchedulerService schedulerService;
+
+    private final ApplicationEventPublisher eventPublisher;
+
+    private final FriendRepository friendRepository;
+
+    @Transactional
+    public void writeDiary(String userId, DiaryRequest diaryRequest) {
+        // 1. 댓글 저장
+        Diary diary = diaryService.writeDiary(userId, diaryRequest);
+
+        // 2. 포인트 적립
+        pointService.earnPointByType(new PointRequest(diary.getMember(), PointType.DIARY));
+
+        // 3. AI 댓글 작성 예약
+        schedulerService.scheduleSavingCommentByAI(diary);
+
+        // 4. 알림 이벤트 발행
+        publishNotification(diary);
+    }
+
+    private void publishNotification(Diary diary) {
+        String senderId = diary.getMember().getUserId();
+        List<Friend> friends = friendRepository.findAllByAccepterUserIdAndFriendStatusOrRequesterUserIdAndFriendStatus(
+                senderId, FriendStatus.ACCEPTED, // requester
+                senderId, FriendStatus.ACCEPTED // acceptor
+        );
+
+        for (Friend friend : friends) {
+            Member member = friend.getFriend(senderId);
+            PublishNotificationRequest notificationRequest = PublishNotificationRequest.of(
+                    senderId,
+                    member.getUserId(),
+                    "post",
+                    diary.getId(),
+                    diary.getCreatedAt()
+            );
+            eventPublisher.publishEvent(notificationRequest);
+        }
+    }
+}

--- a/src/main/java/com/gdg/Todak/diary/facade/DiaryFacade.java
+++ b/src/main/java/com/gdg/Todak/diary/facade/DiaryFacade.java
@@ -3,66 +3,22 @@ package com.gdg.Todak.diary.facade;
 import com.gdg.Todak.diary.dto.DiaryRequest;
 import com.gdg.Todak.diary.entity.Diary;
 import com.gdg.Todak.diary.service.DiaryService;
-import com.gdg.Todak.diary.service.SchedulerService;
-import com.gdg.Todak.friend.FriendStatus;
-import com.gdg.Todak.friend.entity.Friend;
-import com.gdg.Todak.friend.repository.FriendRepository;
-import com.gdg.Todak.member.domain.Member;
-import com.gdg.Todak.notification.dto.PublishNotificationRequest;
-import com.gdg.Todak.point.PointType;
-import com.gdg.Todak.point.dto.PointRequest;
-import com.gdg.Todak.point.service.PointService;
+import com.gdg.Todak.event.event.NewDiaryEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @RequiredArgsConstructor
 @Component
 public class DiaryFacade {
 
     private final DiaryService diaryService;
-    private final PointService pointService;
-    private final SchedulerService schedulerService;
-
     private final ApplicationEventPublisher eventPublisher;
-
-    private final FriendRepository friendRepository;
 
     @Transactional
     public void writeDiary(String userId, DiaryRequest diaryRequest) {
-        // 1. 댓글 저장
         Diary diary = diaryService.writeDiary(userId, diaryRequest);
-
-        // 2. 포인트 적립
-        pointService.earnPointByType(new PointRequest(diary.getMember(), PointType.DIARY));
-
-        // 3. AI 댓글 작성 예약
-        schedulerService.scheduleSavingCommentByAI(diary);
-
-        // 4. 알림 이벤트 발행
-        publishNotification(diary);
-    }
-
-    private void publishNotification(Diary diary) {
-        String senderId = diary.getMember().getUserId();
-        List<Friend> friends = friendRepository.findAllByAccepterUserIdAndFriendStatusOrRequesterUserIdAndFriendStatus(
-                senderId, FriendStatus.ACCEPTED, // requester
-                senderId, FriendStatus.ACCEPTED // acceptor
-        );
-
-        for (Friend friend : friends) {
-            Member member = friend.getFriend(senderId);
-            PublishNotificationRequest notificationRequest = PublishNotificationRequest.of(
-                    senderId,
-                    member.getUserId(),
-                    "post",
-                    diary.getId(),
-                    diary.getCreatedAt()
-            );
-            eventPublisher.publishEvent(notificationRequest);
-        }
+        eventPublisher.publishEvent(NewDiaryEvent.of(diary));
     }
 }

--- a/src/main/java/com/gdg/Todak/diary/service/DiaryService.java
+++ b/src/main/java/com/gdg/Todak/diary/service/DiaryService.java
@@ -9,8 +9,6 @@ import com.gdg.Todak.diary.repository.DiaryRepository;
 import com.gdg.Todak.friend.service.FriendCheckService;
 import com.gdg.Todak.member.domain.Member;
 import com.gdg.Todak.member.repository.MemberRepository;
-import com.gdg.Todak.notification.service.NotificationService;
-import com.gdg.Todak.point.service.PointService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
@@ -30,10 +28,7 @@ public class DiaryService {
     private final DiaryRepository diaryRepository;
     private final MemberRepository memberRepository;
     private final ImageService imageService;
-    private final NotificationService notificationService;
     private final FriendCheckService friendCheckService;
-    private final PointService pointService;
-    private final SchedulerService schedulerService;
 
     @Transactional(propagation = Propagation.REQUIRED)
     public Diary writeDiary(String userId, DiaryRequest diaryRequest) {

--- a/src/main/java/com/gdg/Todak/event/event/NewCommentEvent.java
+++ b/src/main/java/com/gdg/Todak/event/event/NewCommentEvent.java
@@ -1,0 +1,19 @@
+package com.gdg.Todak.event.event;
+
+import com.gdg.Todak.diary.entity.Comment;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class NewCommentEvent {
+    private Comment comment;
+
+    public static NewCommentEvent of(Comment comment) {
+        return NewCommentEvent.builder()
+                .comment(comment)
+                .build();
+    }
+}

--- a/src/main/java/com/gdg/Todak/event/event/NewDiaryEvent.java
+++ b/src/main/java/com/gdg/Todak/event/event/NewDiaryEvent.java
@@ -1,0 +1,19 @@
+package com.gdg.Todak.event.event;
+
+import com.gdg.Todak.diary.entity.Diary;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class NewDiaryEvent {
+    private Diary diary;
+
+    public static NewDiaryEvent of(Diary diary) {
+        return NewDiaryEvent.builder()
+                .diary(diary)
+                .build();
+    }
+}

--- a/src/main/java/com/gdg/Todak/event/event/NewFriendRequestEvent.java
+++ b/src/main/java/com/gdg/Todak/event/event/NewFriendRequestEvent.java
@@ -1,0 +1,19 @@
+package com.gdg.Todak.event.event;
+
+import com.gdg.Todak.friend.entity.Friend;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class NewFriendRequestEvent {
+    private Friend friend;
+
+    public static NewFriendRequestEvent of(Friend friend) {
+        return NewFriendRequestEvent.builder()
+                .friend(friend)
+                .build();
+    }
+}

--- a/src/main/java/com/gdg/Todak/event/listener/AiCommentSchedulingListener.java
+++ b/src/main/java/com/gdg/Todak/event/listener/AiCommentSchedulingListener.java
@@ -1,0 +1,22 @@
+package com.gdg.Todak.event.listener;
+
+import com.gdg.Todak.diary.service.SchedulerService;
+import com.gdg.Todak.event.event.NewDiaryEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@RequiredArgsConstructor
+@Component
+public class AiCommentSchedulingListener {
+
+    private final SchedulerService schedulerService;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleDiarySaved(NewDiaryEvent event) {
+        schedulerService.scheduleSavingCommentByAI(event.getDiary());
+    }
+}

--- a/src/main/java/com/gdg/Todak/event/listener/NewCommentNotificationListener.java
+++ b/src/main/java/com/gdg/Todak/event/listener/NewCommentNotificationListener.java
@@ -1,0 +1,35 @@
+package com.gdg.Todak.event.listener;
+
+import com.gdg.Todak.diary.entity.Comment;
+import com.gdg.Todak.event.event.NewCommentEvent;
+import com.gdg.Todak.notification.dto.PublishNotificationRequest;
+import com.gdg.Todak.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.time.Instant;
+
+
+@Component
+@RequiredArgsConstructor
+public class NewCommentNotificationListener {
+
+    private final NotificationService notificationService;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleCommentSaved(NewCommentEvent event) {
+        Comment comment = event.getComment();
+        String senderId = comment.getMember().getUserId();
+        String receiverId = comment.getDiary().getMember().getUserId();
+        Long diaryId = comment.getDiary().getId();
+        Instant createdAt = comment.getCreatedAt();
+
+        PublishNotificationRequest request = PublishNotificationRequest.of(senderId, receiverId, "comment", diaryId, createdAt);
+
+        notificationService.publishNotification(request);
+    }
+}

--- a/src/main/java/com/gdg/Todak/event/listener/NewDiaryNotificationListener.java
+++ b/src/main/java/com/gdg/Todak/event/listener/NewDiaryNotificationListener.java
@@ -1,0 +1,42 @@
+package com.gdg.Todak.event.listener;
+
+import com.gdg.Todak.diary.entity.Diary;
+import com.gdg.Todak.event.event.NewDiaryEvent;
+import com.gdg.Todak.friend.FriendStatus;
+import com.gdg.Todak.friend.entity.Friend;
+import com.gdg.Todak.friend.repository.FriendRepository;
+import com.gdg.Todak.notification.dto.PublishNotificationRequest;
+import com.gdg.Todak.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class NewDiaryNotificationListener {
+
+    private final NotificationService notificationService;
+    private final FriendRepository friendRepository;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleDiarySaved(NewDiaryEvent event) {
+        Diary diary = event.getDiary();
+        String senderId = diary.getMember().getUserId();
+
+        List<Friend> friends = friendRepository.findAllByAccepterUserIdAndFriendStatusOrRequesterUserIdAndFriendStatus(
+                senderId, FriendStatus.ACCEPTED, // requester
+                senderId, FriendStatus.ACCEPTED // acceptor
+        );
+
+        for (Friend friend : friends) {
+            String receiverId = friend.getFriend(senderId).getUserId();
+            PublishNotificationRequest request = PublishNotificationRequest.of(senderId, receiverId, "diary", diary.getId(), diary.getCreatedAt());
+            notificationService.publishNotification(request);
+        }
+    }
+}

--- a/src/main/java/com/gdg/Todak/event/listener/NewFriendRequestNotificationListener.java
+++ b/src/main/java/com/gdg/Todak/event/listener/NewFriendRequestNotificationListener.java
@@ -1,0 +1,32 @@
+package com.gdg.Todak.event.listener;
+
+import com.gdg.Todak.event.event.NewFriendRequestEvent;
+import com.gdg.Todak.friend.entity.Friend;
+import com.gdg.Todak.notification.dto.PublishNotificationRequest;
+import com.gdg.Todak.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.time.Instant;
+
+@Component
+@RequiredArgsConstructor
+public class NewFriendRequestNotificationListener {
+
+    private final NotificationService notificationService;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleDiarySaved(NewFriendRequestEvent event) {
+        Friend friend = event.getFriend();
+        String senderId = friend.getRequester().getUserId();
+        String receiverId = friend.getAccepter().getUserId();
+
+        PublishNotificationRequest request = PublishNotificationRequest.of(senderId, receiverId, "friend", null, Instant.now());
+
+        notificationService.publishNotification(request);
+    }
+}

--- a/src/main/java/com/gdg/Todak/event/listener/PointEarningListener.java
+++ b/src/main/java/com/gdg/Todak/event/listener/PointEarningListener.java
@@ -1,0 +1,49 @@
+package com.gdg.Todak.event.listener;
+
+import com.gdg.Todak.common.lock.exception.LockException;
+import com.gdg.Todak.event.event.NewCommentEvent;
+import com.gdg.Todak.event.event.NewDiaryEvent;
+import com.gdg.Todak.point.PointType;
+import com.gdg.Todak.point.dto.PointRequest;
+import com.gdg.Todak.point.service.PointService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DeadlockLoserDataAccessException;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class PointEarningListener {
+
+    private final PointService pointService;
+
+    @Async
+    @Retryable(
+            value = {
+                    LockException.class,
+                    DeadlockLoserDataAccessException.class
+            },
+            backoff = @Backoff(delay = 1000)
+    )
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleCommentSaved(NewCommentEvent event) {
+        pointService.earnPointByType(PointRequest.of(event.getComment().getMember(), PointType.COMMENT));
+    }
+
+    @Async
+    @Retryable(
+            value = {
+                    LockException.class,
+                    DeadlockLoserDataAccessException.class
+            },
+            backoff = @Backoff(delay = 1000)
+    )
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleDiarySaved(NewDiaryEvent event) {
+        pointService.earnPointByType(PointRequest.of(event.getDiary().getMember(), PointType.DIARY));
+    }
+}

--- a/src/main/java/com/gdg/Todak/friend/controller/FriendController.java
+++ b/src/main/java/com/gdg/Todak/friend/controller/FriendController.java
@@ -2,6 +2,7 @@ package com.gdg.Todak.friend.controller;
 
 import com.gdg.Todak.common.domain.ApiResponse;
 import com.gdg.Todak.friend.dto.*;
+import com.gdg.Todak.friend.facade.FriendFacade;
 import com.gdg.Todak.friend.service.FriendService;
 import com.gdg.Todak.member.domain.AuthenticateUser;
 import com.gdg.Todak.member.resolver.Login;
@@ -20,13 +21,14 @@ import java.util.List;
 @Tag(name = "친구", description = "친구 관련 API")
 public class FriendController {
 
+    private final FriendFacade friendFacade;
     private final FriendService friendService;
 
     @Operation(summary = "친구 요청 보내기", description = "친구의 이름을 기반으로 친구요청합니다.")
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public ApiResponse<Void> sendFriendRequest(@Parameter(hidden = true) @Login AuthenticateUser authenticateUser, @RequestBody FriendIdRequest friendIdRequest) {
-        friendService.makeFriendRequest(authenticateUser.getUserId(), friendIdRequest);
+        friendFacade.makeFriendRequest(authenticateUser.getUserId(), friendIdRequest);
         return ApiResponse.of(HttpStatus.CREATED, "친구 요청이 생성되었습니다.");
     }
 

--- a/src/main/java/com/gdg/Todak/friend/facade/FriendFacade.java
+++ b/src/main/java/com/gdg/Todak/friend/facade/FriendFacade.java
@@ -1,0 +1,24 @@
+package com.gdg.Todak.friend.facade;
+
+import com.gdg.Todak.event.event.NewFriendRequestEvent;
+import com.gdg.Todak.friend.dto.FriendIdRequest;
+import com.gdg.Todak.friend.entity.Friend;
+import com.gdg.Todak.friend.service.FriendService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Component
+public class FriendFacade {
+
+    private final FriendService friendService;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Transactional
+    public void makeFriendRequest(String userId, FriendIdRequest friendIdRequest) {
+        Friend friend = friendService.makeFriendRequest(userId, friendIdRequest);
+        eventPublisher.publishEvent(NewFriendRequestEvent.of(friend));
+    }
+}

--- a/src/main/java/com/gdg/Todak/notification/dto/PublishNotificationRequest.java
+++ b/src/main/java/com/gdg/Todak/notification/dto/PublishNotificationRequest.java
@@ -13,15 +13,15 @@ public class PublishNotificationRequest {
     private String senderId;
     private String receiverId;
     private String type;
-    private Long diaryId;
+    private Long objectId;
     private Instant createdAt;
 
-    public static PublishNotificationRequest of(String senderId, String receiverId, String type, Long diaryId, Instant createdAt) {
+    public static PublishNotificationRequest of(String senderId, String receiverId, String type, Long objectId, Instant createdAt) {
         return PublishNotificationRequest.builder()
                 .senderId(senderId)
                 .receiverId(receiverId)
                 .type(type)
-                .diaryId(diaryId)
+                .objectId(objectId)
                 .createdAt(createdAt)
                 .build();
     }

--- a/src/main/java/com/gdg/Todak/notification/dto/PublishNotificationRequest.java
+++ b/src/main/java/com/gdg/Todak/notification/dto/PublishNotificationRequest.java
@@ -1,0 +1,28 @@
+package com.gdg.Todak.notification.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.Instant;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class PublishNotificationRequest {
+    private String senderId;
+    private String receiverId;
+    private String type;
+    private Long diaryId;
+    private Instant createdAt;
+
+    public static PublishNotificationRequest of(String senderId, String receiverId, String type, Long diaryId, Instant createdAt) {
+        return PublishNotificationRequest.builder()
+                .senderId(senderId)
+                .receiverId(receiverId)
+                .type(type)
+                .diaryId(diaryId)
+                .createdAt(createdAt)
+                .build();
+    }
+}

--- a/src/main/java/com/gdg/Todak/point/dto/PointRequest.java
+++ b/src/main/java/com/gdg/Todak/point/dto/PointRequest.java
@@ -7,4 +7,7 @@ public record PointRequest(
         Member member,
         PointType pointType
 ) {
+    public static PointRequest of(Member member, PointType pointType) {
+        return new PointRequest(member, pointType);
+    }
 }

--- a/src/main/java/com/gdg/Todak/point/facade/PointFacade.java
+++ b/src/main/java/com/gdg/Todak/point/facade/PointFacade.java
@@ -1,0 +1,52 @@
+package com.gdg.Todak.point.facade;
+
+import com.gdg.Todak.common.lock.LockExecutor;
+import com.gdg.Todak.member.domain.Member;
+import com.gdg.Todak.point.dto.PointRequest;
+import com.gdg.Todak.point.service.PointService;
+import com.gdg.Todak.tree.domain.GrowthButton;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class PointFacade {
+
+    private final static String LOCK_PREFIX = "pointLock:";
+
+    private final LockExecutor lockExecutor;
+    private final PointService pointService;
+
+    public void earnAttendancePointPerDay(Member member) {
+        lockExecutor.executeWithLock(
+                LOCK_PREFIX,
+                member,
+                () -> pointService.earnAttendancePointPerDay(member)
+        );
+    }
+
+    public void earnPointByType(PointRequest pointRequest) {
+        Member member = pointRequest.member();
+        lockExecutor.executeWithLock(
+                LOCK_PREFIX,
+                member,
+                () -> pointService.earnPointByType(pointRequest)
+        );
+    }
+
+    public void consumePointByGrowthButton(Member member, GrowthButton growthButton) {
+        lockExecutor.executeWithLock(
+                LOCK_PREFIX,
+                member,
+                () -> pointService.consumePointByGrowthButton(member, growthButton)
+        );
+    }
+
+    public void consumePointToGetCommentWriterId(Member member) {
+        lockExecutor.executeWithLock(
+                LOCK_PREFIX,
+                member,
+                () -> pointService.consumePointToGetCommentWriterId(member)
+        );
+    }
+}

--- a/src/main/java/com/gdg/Todak/point/service/PointService.java
+++ b/src/main/java/com/gdg/Todak/point/service/PointService.java
@@ -17,6 +17,7 @@ import com.gdg.Todak.point.repository.PointRepository;
 import com.gdg.Todak.tree.domain.GrowthButton;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
@@ -133,7 +134,7 @@ public class PointService {
         };
     }
 
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRED)
     public void earnPointByType(PointRequest pointRequest) {
         String lockKey = LOCK_PREFIX + pointRequest.member().getId();
 
@@ -186,7 +187,7 @@ public class PointService {
 
         Point point = getPoint(member);
         PointType pointType = PointType.GET_COMMENT_WRITER_ID;
-        
+
         int consumedPoint = point.consumePointToGetCommentWriterId(GET_COMMENT_WRITER_ID_POINT);
 
         pointLogService.createPointLog(new PointLogRequest(member, consumedPoint, pointType, PointStatus.CONSUMED, LocalDateTime.now()));


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #-


## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.(이미지 첨부 가능)
- **Facade 계층 도입으로 SRP(단일 책임 원칙) 준수**: Service 계층이 순수 비즈니스 로직에만 집중하도록, 트랜잭션 관리, 분산 락, 이벤트 발행 등의 기술적인 처리를 담당하는 Facade 계층을 도입하여 각 클래스의 역할을 명확히 분리했습니다.

- **이벤트 기반 비동기 처리로 핵심 로직과 부가 기능 분리**: 알림 전송이나 AI 댓글 생성과 같은 부가 기능의 실패가 일기 작성 등 핵심 기능의 트랜잭션을 롤백시키는 문제를 해결하기 위해, Spring의 ApplicationEvent를 활용한 비동기 처리 방식으로 전환했습니다. 이를 통해 시스템의 결합도를 낮추고 안정성을 높였습니다.

- **분산 락 획득과 트랜잭션 시작 시점 분리**: 분산 락을 획득하기 위해 대기하는 시간 동안 불필요하게 DB 커넥션이 점유되는 문제를 해결했습니다. 락을 먼저 획득한 후에 트랜잭션을 시작하도록 순서를 변경하여, DB 커넥션 점유 시간을 최소화하고 시스템 전체의 성능과 안정성을 향상시켰습니다.

### 스크린샷 (선택)
-

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
>-


## ⏰ 현재 버그
- 현재 다른 메인 로직과 관련 없는 부분들이 한 트랜잭션 내에서 진행되는 경우가 있습니다. 예를 들어 로그 저장과 같은 로직들도 이벤트 기반 비동기 처리로 리펙토링하면 좋을 것 같습니다.
- 비동기로 처리된 포인트 획득 로직등에 대해 실패를 대비하여 포인트 저장/소비 로그 기반 자동 보정 로직으로 정합성 문제를 해결할 수 있으면 좋을 것 같습니다.

## ✏ Git Close
> close #-
