### PR TITLE
Feat: Implement a scheduler for daily point reconciliation

### DIFF
--- a/src/main/java/com/gdg/Todak/point/entity/Point.java
+++ b/src/main/java/com/gdg/Todak/point/entity/Point.java
@@ -86,4 +86,8 @@ public class Point {
             default -> throw new BadRequestException("올바른 growthButton이 아닙니다.");
         }
     }
+
+    public void updatePoint(int calculatedTotalPoint) {
+        this.point = calculatedTotalPoint;
+    }
 }

--- a/src/main/java/com/gdg/Todak/point/repository/PointLogRepository.java
+++ b/src/main/java/com/gdg/Todak/point/repository/PointLogRepository.java
@@ -8,9 +8,12 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
@@ -30,4 +33,10 @@ public interface PointLogRepository extends JpaRepository<PointLog, Long> {
     List<PointLog> findAllByCreatedAtBetween(Instant start, Instant end);
 
     Page<PointLog> findAll(Specification<PointLog> spec, Pageable pageable);
+
+    @Query("SELECT DISTINCT pl.member.id FROM PointLog pl WHERE pl.createdAt BETWEEN :start AND :end")
+    List<Long> findMemberIdsWithActivityBetween(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
+
+    @Query("SELECT SUM(pl.point) FROM PointLog pl WHERE pl.member.id = :memberId")
+    int sumPointsByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/gdg/Todak/point/repository/PointLogRepository.java
+++ b/src/main/java/com/gdg/Todak/point/repository/PointLogRepository.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Repository;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface PointLogRepository extends JpaRepository<PointLog, Long> {
@@ -37,6 +38,11 @@ public interface PointLogRepository extends JpaRepository<PointLog, Long> {
     @Query("SELECT DISTINCT pl.member.id FROM PointLog pl WHERE pl.createdAt BETWEEN :start AND :end")
     List<Long> findMemberIdsWithActivityBetween(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
 
-    @Query("SELECT SUM(pl.point) FROM PointLog pl WHERE pl.member.id = :memberId")
-    int sumPointsByMemberId(@Param("memberId") Long memberId);
+    @Query("""
+                SELECT COALESCE(SUM(CASE WHEN pl.pointStatus = 'EARNED' THEN pl.point ELSE 0 END), 0) - 
+                       COALESCE(SUM(CASE WHEN pl.pointStatus = 'CONSUMED' THEN pl.point ELSE 0 END), 0)
+                FROM PointLog pl
+                WHERE pl.member.id = :memberId
+            """)
+    Optional<Integer> sumPointsByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/gdg/Todak/point/repository/PointRepository.java
+++ b/src/main/java/com/gdg/Todak/point/repository/PointRepository.java
@@ -12,4 +12,6 @@ public interface PointRepository extends JpaRepository<Point, Long> {
     boolean existsByMember(Member member);
 
     Optional<Point> findByMember(Member member);
+
+    Point findByMemberId(Long memberId);
 }

--- a/src/main/java/com/gdg/Todak/point/scheduler/PointReconciliationScheduler.java
+++ b/src/main/java/com/gdg/Todak/point/scheduler/PointReconciliationScheduler.java
@@ -1,0 +1,38 @@
+package com.gdg.Todak.point.scheduler;
+
+import com.gdg.Todak.point.service.PointReconciliationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class PointReconciliationScheduler {
+
+    private final PointReconciliationService pointReconciliationService;
+
+    @Scheduled(cron = "0 0 4 * * *")
+    public void reconcilePoints() {
+        log.info("포인트 정합성 보정 작업 시작");
+
+        LocalDateTime start = LocalDate.now().minusDays(1).atStartOfDay();
+        LocalDateTime end = start.plusDays(1).minusNanos(1);
+
+        List<Long> memberIds = pointReconciliationService.getTargetMembers(start, end);
+        for (Long memberId : memberIds) {
+            try {
+                pointReconciliationService.reconcilePoint(memberId);
+            } catch (Exception e) {
+                log.error("포인트 보정 중 오류 발생 | Member ID: {}", memberId, e);
+            }
+        }
+
+        log.info("포인트 정합성 보정 작업 완료");
+    }
+}

--- a/src/main/java/com/gdg/Todak/point/service/PointReconciliationService.java
+++ b/src/main/java/com/gdg/Todak/point/service/PointReconciliationService.java
@@ -1,0 +1,39 @@
+package com.gdg.Todak.point.service;
+
+import com.gdg.Todak.point.entity.Point;
+import com.gdg.Todak.point.repository.PointLogRepository;
+import com.gdg.Todak.point.repository.PointRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class PointReconciliationService {
+
+    private final PointLogRepository pointLogRepository;
+    private final PointRepository pointRepository;
+
+    @Transactional(readOnly = true)
+    public List<Long> getTargetMembers(LocalDateTime start, LocalDateTime end) {
+        return pointLogRepository.findMemberIdsWithActivityBetween(start, end);
+    }
+
+    @Transactional
+    public void reconcilePoint(Long memberId) {
+        int calculatedTotalPoint = pointLogRepository.sumPointsByMemberId(memberId);
+
+        Point findPoint = pointRepository.findByMemberId(memberId);
+        int currentPoint = findPoint.getPoint();
+
+        if (calculatedTotalPoint != currentPoint) {
+            log.warn("포인트 불일치 | Member ID: {}, DB 저장값: {}, 로그 계산값: {}", memberId, currentPoint, calculatedTotalPoint);
+            findPoint.updatePoint(calculatedTotalPoint);
+        }
+    }
+}

--- a/src/main/java/com/gdg/Todak/point/service/PointReconciliationService.java
+++ b/src/main/java/com/gdg/Todak/point/service/PointReconciliationService.java
@@ -26,7 +26,7 @@ public class PointReconciliationService {
 
     @Transactional
     public void reconcilePoint(Long memberId) {
-        int calculatedTotalPoint = pointLogRepository.sumPointsByMemberId(memberId);
+        int calculatedTotalPoint = pointLogRepository.sumPointsByMemberId(memberId).orElse(0);
 
         Point findPoint = pointRepository.findByMemberId(memberId);
         int currentPoint = findPoint.getPoint();


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #-


## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.(이미지 첨부 가능)
1. 포인트 정합성 보장 스케줄러 구현
- 비동기 처리 중 발생할 수 있는 데이터 유실에 대비하여, 포인트 데이터의 최종적 일관성(Eventual Consistency)을 보장하기 위한 스케줄러를 구현했습니다. 이 스케줄러는 매일 새벽 4시에 주기적으로 실행되며, 다음과 같은 로직을 수행합니다.
    - 지난 하루 동안 포인트 변동이 있었던 사용자를 대상으로 합니다.
    - PointLog의 전체 기록을 바탕으로 정확한 현재 포인트를 계산합니다.
    - 계산된 값과 현재 Point 테이블의 값이 일치하지 않을 경우, 로그 기반의 정확한 값으로 데이터를 보정합니다.

2. 배치 작업의 트랜잭션 최적화
- 배치 작업의 안정성과 성능을 향상시키기 위해, 조회와 수정 로직의 트랜잭션을 분리했습니다.
- 기존 방식대로라면 모든 사용자에 대한 보정 작업이 단일 트랜잭션 내에서 실행되어, 대상 사용자가 많아질 경우 DB 커넥션을 장시간 점유하는 문제가 발생할 수 있었습니다.
- Scheduler는 트랜잭션 없이 전체적인 작업 흐름만 제어하며, Service를 통해 read-only 트랜잭션 안에서 보정 대상 목록을 조회합니다.
- Service의 보정 메서드(reconcilePoint)에만 @Transactional을 적용하여, for 루프를 통해 호출될 때마다 짧고 독립적인 트랜잭션이 생성되도록 구현했습니다.

### 스크린샷 (선택)
-

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> -


## ⏰ 현재 버그
현재 구현된 포인트 정합성 보정 로직은 사용자의 전체 포인트 로그(PointLog)를 매번 합산하여 정확한 값을 계산합니다. 서비스 규모가 작은 현 단계에서는 이 방식이 가장 단순하고 확실하지만, 장기적으로 사용자 및 로그 데이터가 대량으로 누적될 경우 배치 작업의 성능 저하를 유발할 수 있습니다.

이에 따라, 추후 시스템의 확장성을 확보하기 위해 특정 시점의 포인트 총계를 별도로 저장하는 스냅샷 기반의 최적화를 적용할 계획입니다. 이 방식을 도입하면, 매번 전체 로그를 스캔할 필요 없이 마지막 스냅샷 이후의 로그 변경분만 계산하여 데이터 정합성을 맞출 수 있으므로 배치 작업의 성능을 크게 향상시킬 수 있을 것입니다.

## ✏ Git Close
> close #-
