### PR TITLE
Feat: Apply point facade

### DIFF
--- a/src/main/java/com/gdg/Todak/diary/service/CommentService.java
+++ b/src/main/java/com/gdg/Todak/diary/service/CommentService.java
@@ -19,7 +19,7 @@ import com.gdg.Todak.diary.util.MBTISelector;
 import com.gdg.Todak.friend.service.FriendCheckService;
 import com.gdg.Todak.member.domain.Member;
 import com.gdg.Todak.member.repository.MemberRepository;
-import com.gdg.Todak.point.service.PointService;
+import com.gdg.Todak.point.facade.PointFacade;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.model.chat.ChatLanguageModel;
 import jakarta.annotation.PostConstruct;
@@ -48,7 +48,7 @@ public class CommentService {
     private final DiaryRepository diaryRepository;
     private final CommentAnonymousRevealRepository commentAnonymousRevealRepository;
     private final FriendCheckService friendCheckService;
-    private final PointService pointService;
+    private final PointFacade pointFacade;
     private final MBTISelector mbtiSelector;
     private final AiModelConfig aiModelConfig;
     private final ObjectMapper objectMapper;
@@ -165,7 +165,7 @@ public class CommentService {
             throw new BadRequestException("본인이 작성한 댓글은 익명 해제가 필요하지 않습니다.");
         }
 
-        pointService.consumePointToGetCommentWriterId(member);
+        pointFacade.consumePointToGetCommentWriterId(member);
 
         commentAnonymousRevealRepository.save(CommentAnonymousReveal.of(member, comment));
 

--- a/src/main/java/com/gdg/Todak/event/event/LoginEvent.java
+++ b/src/main/java/com/gdg/Todak/event/event/LoginEvent.java
@@ -1,0 +1,20 @@
+package com.gdg.Todak.event.event;
+
+import com.gdg.Todak.friend.entity.Friend;
+import com.gdg.Todak.member.domain.Member;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class LoginEvent {
+    private Member member;
+
+    public static LoginEvent of(Member member) {
+        return LoginEvent.builder()
+                .member(member)
+                .build();
+    }
+}

--- a/src/main/java/com/gdg/Todak/point/service/PointService.java
+++ b/src/main/java/com/gdg/Todak/point/service/PointService.java
@@ -17,6 +17,7 @@ import com.gdg.Todak.point.repository.PointRepository;
 import com.gdg.Todak.tree.domain.GrowthButton;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
@@ -149,7 +150,7 @@ public class PointService {
         };
     }
 
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void consumePointByGrowthButton(Member member, GrowthButton growthButton) {
         Point point = getPoint(member);
         PointType pointType = point.convertPointTypeByGrowthButton(growthButton);

--- a/src/main/java/com/gdg/Todak/tree/business/TreeService.java
+++ b/src/main/java/com/gdg/Todak/tree/business/TreeService.java
@@ -4,7 +4,7 @@ import com.gdg.Todak.friend.service.FriendCheckService;
 import com.gdg.Todak.member.domain.Member;
 import com.gdg.Todak.member.repository.MemberRepository;
 import com.gdg.Todak.point.exception.NotFoundException;
-import com.gdg.Todak.point.service.PointService;
+import com.gdg.Todak.point.facade.PointFacade;
 import com.gdg.Todak.tree.business.dto.TreeInfoResponse;
 import com.gdg.Todak.tree.domain.GrowthButton;
 import com.gdg.Todak.tree.domain.Tree;
@@ -23,7 +23,7 @@ public class TreeService {
 
     private final TreeRepository treeRepository;
     private final MemberRepository memberRepository;
-    private final PointService pointService;
+    private final PointFacade pointFacade;
     private final FriendCheckService friendCheckService;
 
     @Transactional
@@ -45,7 +45,7 @@ public class TreeService {
             throw new BadRequestException("최고 레벨입니다.");
         }
 
-        pointService.consumePointByGrowthButton(member, growthButton);
+        pointFacade.consumePointByGrowthButton(member, growthButton);
         tree.earnExperience(growthButton);
 
         treeRepository.update(member, tree.toTreeEntityUpdateRequest());


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #-


## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.(이미지 첨부 가능)
1. PointFacade 계층 도입:
- 분산 락(LockExecutor)을 이용한 동시성 제어와 실제 포인트 비즈니스 로직(PointService)의 호출을 중재하는 PointFacade 계층을 새롭게 도입하여 책임을 분리했습니다.

2. 포인트 획득 로직의 비동기 처리:
- 포인트 획득은 핵심 로직(로그인, 게시글/댓글 작성)의 성공이 더 중요하다고 판단하여, TransactionalEventListener를 활용한 이벤트 기반 비동기 처리 방식으로 변경했습니다. 이를 통해 사용자의 핵심 액션 응답 시간을 단축시켰습니다.

3. 포인트 차감 로직의 동기 처리 유지:
- 포인트 차감은 비용 지불이 반드시 선행되고 보장되어야 하는 작업이므로, 기존과 같이 동기 방식으로 처리하여 데이터 정합성을 유지했습니다.
- 특히, REQUIRES_NEW 전파 속성을 활용해 포인트 차감 트랜잭션을 분리하여 안정성을 높였습니다.

### 스크린샷 (선택)
-

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> -


## ⏰ 현재 버그

-
## ✏ Git Close
> close #-
