### PR TITLE
Refactor: Improve Event Handling and Retry Backoff Strategy

### DIFF
--- a/src/main/java/com/gdg/Todak/diary/facade/CommentFacade.java
+++ b/src/main/java/com/gdg/Todak/diary/facade/CommentFacade.java
@@ -7,7 +7,6 @@ import com.gdg.Todak.event.event.NewCommentEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Component
@@ -16,7 +15,6 @@ public class CommentFacade {
     private final CommentService commentService;
     private final ApplicationEventPublisher eventPublisher;
 
-    @Transactional
     public void saveComment(String userId, Long diaryId, CommentRequest request) {
         Comment comment = commentService.saveComment(userId, diaryId, request);
         eventPublisher.publishEvent(NewCommentEvent.of(comment));

--- a/src/main/java/com/gdg/Todak/diary/facade/DiaryFacade.java
+++ b/src/main/java/com/gdg/Todak/diary/facade/DiaryFacade.java
@@ -7,7 +7,6 @@ import com.gdg.Todak.event.event.NewDiaryEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Component
@@ -16,7 +15,6 @@ public class DiaryFacade {
     private final DiaryService diaryService;
     private final ApplicationEventPublisher eventPublisher;
 
-    @Transactional
     public void writeDiary(String userId, DiaryRequest diaryRequest) {
         Diary diary = diaryService.writeDiary(userId, diaryRequest);
         eventPublisher.publishEvent(NewDiaryEvent.of(diary));

--- a/src/main/java/com/gdg/Todak/diary/service/CommentService.java
+++ b/src/main/java/com/gdg/Todak/diary/service/CommentService.java
@@ -109,7 +109,7 @@ public class CommentService {
         return commentAnonymousRevealRepository.existsByMemberAndComment(member, comment);
     }
 
-    @Transactional(propagation = Propagation.REQUIRED)
+    @Transactional
     public Comment saveComment(String userId, Long diaryId, CommentRequest commentRequest) {
         Member member = getMember(userId);
         Diary diary = getDiary(diaryId);

--- a/src/main/java/com/gdg/Todak/diary/service/DiaryService.java
+++ b/src/main/java/com/gdg/Todak/diary/service/DiaryService.java
@@ -11,7 +11,6 @@ import com.gdg.Todak.member.domain.Member;
 import com.gdg.Todak.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
@@ -30,7 +29,7 @@ public class DiaryService {
     private final ImageService imageService;
     private final FriendCheckService friendCheckService;
 
-    @Transactional(propagation = Propagation.REQUIRED)
+    @Transactional
     public Diary writeDiary(String userId, DiaryRequest diaryRequest) {
         Member member = getMember(userId);
 

--- a/src/main/java/com/gdg/Todak/event/event/LoginEvent.java
+++ b/src/main/java/com/gdg/Todak/event/event/LoginEvent.java
@@ -1,6 +1,5 @@
 package com.gdg.Todak.event.event;
 
-import com.gdg.Todak.friend.entity.Friend;
 import com.gdg.Todak.member.domain.Member;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/gdg/Todak/event/listener/AiCommentSchedulingListener.java
+++ b/src/main/java/com/gdg/Todak/event/listener/AiCommentSchedulingListener.java
@@ -3,10 +3,9 @@ package com.gdg.Todak.event.listener;
 import com.gdg.Todak.diary.service.SchedulerService;
 import com.gdg.Todak.event.event.NewDiaryEvent;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionPhase;
-import org.springframework.transaction.event.TransactionalEventListener;
 
 @RequiredArgsConstructor
 @Component
@@ -15,7 +14,7 @@ public class AiCommentSchedulingListener {
     private final SchedulerService schedulerService;
 
     @Async
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @EventListener
     public void handleDiarySaved(NewDiaryEvent event) {
         schedulerService.scheduleSavingCommentByAI(event.getDiary());
     }

--- a/src/main/java/com/gdg/Todak/event/listener/NewCommentNotificationListener.java
+++ b/src/main/java/com/gdg/Todak/event/listener/NewCommentNotificationListener.java
@@ -5,10 +5,9 @@ import com.gdg.Todak.event.event.NewCommentEvent;
 import com.gdg.Todak.notification.dto.PublishNotificationRequest;
 import com.gdg.Todak.notification.service.NotificationService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionPhase;
-import org.springframework.transaction.event.TransactionalEventListener;
 
 import java.time.Instant;
 
@@ -20,7 +19,7 @@ public class NewCommentNotificationListener {
     private final NotificationService notificationService;
 
     @Async
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @EventListener
     public void handleCommentSaved(NewCommentEvent event) {
         Comment comment = event.getComment();
         String senderId = comment.getMember().getUserId();

--- a/src/main/java/com/gdg/Todak/event/listener/NewDiaryNotificationListener.java
+++ b/src/main/java/com/gdg/Todak/event/listener/NewDiaryNotificationListener.java
@@ -8,10 +8,9 @@ import com.gdg.Todak.friend.repository.FriendRepository;
 import com.gdg.Todak.notification.dto.PublishNotificationRequest;
 import com.gdg.Todak.notification.service.NotificationService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionPhase;
-import org.springframework.transaction.event.TransactionalEventListener;
 
 import java.util.List;
 
@@ -23,7 +22,7 @@ public class NewDiaryNotificationListener {
     private final FriendRepository friendRepository;
 
     @Async
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @EventListener
     public void handleDiarySaved(NewDiaryEvent event) {
         Diary diary = event.getDiary();
         String senderId = diary.getMember().getUserId();

--- a/src/main/java/com/gdg/Todak/event/listener/NewFriendRequestNotificationListener.java
+++ b/src/main/java/com/gdg/Todak/event/listener/NewFriendRequestNotificationListener.java
@@ -5,10 +5,9 @@ import com.gdg.Todak.friend.entity.Friend;
 import com.gdg.Todak.notification.dto.PublishNotificationRequest;
 import com.gdg.Todak.notification.service.NotificationService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionPhase;
-import org.springframework.transaction.event.TransactionalEventListener;
 
 import java.time.Instant;
 
@@ -19,7 +18,7 @@ public class NewFriendRequestNotificationListener {
     private final NotificationService notificationService;
 
     @Async
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @EventListener
     public void handleDiarySaved(NewFriendRequestEvent event) {
         Friend friend = event.getFriend();
         String senderId = friend.getRequester().getUserId();

--- a/src/main/java/com/gdg/Todak/event/listener/PointEarningListener.java
+++ b/src/main/java/com/gdg/Todak/event/listener/PointEarningListener.java
@@ -8,6 +8,7 @@ import com.gdg.Todak.point.PointType;
 import com.gdg.Todak.point.dto.PointRequest;
 import com.gdg.Todak.point.facade.PointFacade;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
 import org.springframework.dao.DeadlockLoserDataAccessException;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
@@ -20,6 +21,9 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @RequiredArgsConstructor
 public class PointEarningListener {
 
+    public static final int DELAY = 100;
+    public static final int MULTIPLIER = 2;
+
     private final PointFacade pointFacade;
 
     @Async
@@ -28,7 +32,7 @@ public class PointEarningListener {
                     LockException.class,
                     DeadlockLoserDataAccessException.class
             },
-            backoff = @Backoff(delay = 1000)
+            backoff = @Backoff(delay = DELAY, multiplier = MULTIPLIER, random = true)
     )
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleLogin(LoginEvent event) {
@@ -41,9 +45,9 @@ public class PointEarningListener {
                     LockException.class,
                     DeadlockLoserDataAccessException.class
             },
-            backoff = @Backoff(delay = 1000)
+            backoff = @Backoff(delay = DELAY, multiplier = MULTIPLIER, random = true)
     )
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @EventListener
     public void handleCommentSaved(NewCommentEvent event) {
         pointFacade.earnPointByType(PointRequest.of(event.getComment().getMember(), PointType.COMMENT));
     }
@@ -54,9 +58,9 @@ public class PointEarningListener {
                     LockException.class,
                     DeadlockLoserDataAccessException.class
             },
-            backoff = @Backoff(delay = 1000)
+            backoff = @Backoff(delay = DELAY, multiplier = MULTIPLIER, random = true)
     )
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @EventListener
     public void handleDiarySaved(NewDiaryEvent event) {
         pointFacade.earnPointByType(PointRequest.of(event.getDiary().getMember(), PointType.DIARY));
     }

--- a/src/main/java/com/gdg/Todak/friend/facade/FriendFacade.java
+++ b/src/main/java/com/gdg/Todak/friend/facade/FriendFacade.java
@@ -7,7 +7,6 @@ import com.gdg.Todak.friend.service.FriendService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Component
@@ -16,7 +15,6 @@ public class FriendFacade {
     private final FriendService friendService;
     private final ApplicationEventPublisher eventPublisher;
 
-    @Transactional
     public void makeFriendRequest(String userId, FriendIdRequest friendIdRequest) {
         Friend friend = friendService.makeFriendRequest(userId, friendIdRequest);
         eventPublisher.publishEvent(NewFriendRequestEvent.of(friend));

--- a/src/main/java/com/gdg/Todak/friend/service/FriendService.java
+++ b/src/main/java/com/gdg/Todak/friend/service/FriendService.java
@@ -12,7 +12,6 @@ import com.gdg.Todak.member.repository.MemberRepository;
 import com.gdg.Todak.notification.service.NotificationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -27,7 +26,7 @@ public class FriendService {
     private final MemberRepository memberRepository;
     private final NotificationService notificationService;
 
-    @Transactional(propagation = Propagation.REQUIRED)
+    @Transactional
     public Friend makeFriendRequest(String userId, FriendIdRequest friendIdRequest) {
         Member requesterMember = getMember(userId);
         Member accepterMember = memberRepository.findByUserId(friendIdRequest.friendId())


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #-


## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.(이미지 첨부 가능)
1. 트랜잭션 경계를 분리하고 이벤트 처리 시점을 분리하였습니다.
- 반환값이 없어 이벤트 발행과 분리할 수 있는 부분은 더 짧은 트랜잭션 범위를 위해 `@Transactional`을 제거하고 `@EventListener`로 변경하였습니다.
- 트랜잭션이 커밋된 후에 이벤트 발행이 보장되기 때문에 `@TransactionalEventListener`와 `after-commit` 옵션을 제거하였습니다.
2. 재시도 백오프 전략 개선
- 기존에는 예외 발생 시 1000ms(1초) 동안 대기하는 방식이었습니다.
- 개선 후 지터를 추가하였습니다.
    - 개선 후 예외 발생 시 100ms, 200ms, 400ms, ...  동안 대기하고 random 옵션으로 해당 범위 사이의 랜덤 시간만큼 대기하도록 하여 재시도 폭풍을 방지할 수 있도록 개선하였습니다.
- 또한 기존 대기 시간 1000ms은 락 경합과 같은 짧은 시간 안에 해결될 수 있는 문제에 대응하기엔 너무 긴 시간이라 판단되어 초기 딜레이를 100ms로 줄였습니다.

### 스크린샷 (선택)
-

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> -


## ⏰ 현재 버그
-

## ✏ Git Close
> close #-
