### PR TITLE
Refactor: Separate Member lookup to MemberService and optimize transactional boundaries in point reconciliation

### DIFF
--- a/src/main/java/com/gdg/Todak/member/service/MemberService.java
+++ b/src/main/java/com/gdg/Todak/member/service/MemberService.java
@@ -99,7 +99,7 @@ public class MemberService {
     @Transactional
     public LoginResponse login(LoginServiceRequest request) {
 
-        Member member = findMember(request.getUserId());
+        Member member = findMemberByUserId(request.getUserId());
 
         checkPassword(request.getPassword(), member);
 
@@ -119,7 +119,7 @@ public class MemberService {
 
     public LogoutResponse logout(AuthenticateUser user) {
         if (user != null) {
-            Member member = findMember(user.getUserId());
+            Member member = findMemberByUserId(user.getUserId());
             redisTemplate.delete(member.getId());
         }
 
@@ -129,13 +129,13 @@ public class MemberService {
     }
 
     public MeResponse me(AuthenticateUser user) {
-        Member member = findMember(user.getUserId());
+        Member member = findMemberByUserId(user.getUserId());
         return MeResponse.from(member);
     }
 
     @Transactional
     public MeResponse editMemberNickname(AuthenticateUser user, EditMemberNicknameServiceRequest serviceRequest) {
-        Member member = findMember(user.getUserId());
+        Member member = findMemberByUserId(user.getUserId());
         member.setNickname(serviceRequest.getNickname());
         return MeResponse.of(member.getUserId(), member.getNickname(), member.getImageUrl());
     }
@@ -163,7 +163,7 @@ public class MemberService {
         File destinationFile = new File(uploadDestination);
 
         try {
-            Member member = findMember(user.getUserId());
+            Member member = findMemberByUserId(user.getUserId());
             if (!member.getImageUrl().equals(defaultProfileImageUrl)) {
                 deleteAllImagesInFolder(uploadFolder + subDirectory);
             }
@@ -178,7 +178,7 @@ public class MemberService {
 
     @Transactional
     public String deleteMemberProfileImage(AuthenticateUser user) {
-        Member member = findMember(user.getUserId());
+        Member member = findMemberByUserId(user.getUserId());
         deleteAllImagesInFolder(uploadFolder + user.getUserId() + "/profile_image");
         member.updateImageUrl(defaultProfileImageUrl);
         return "프로필 이미지가 삭제되고 기본 이미지로 변경되었습니다.";
@@ -203,7 +203,7 @@ public class MemberService {
 
     @Transactional
     public String changePassword(AuthenticateUser user, ChangePasswordServiceRequest request) {
-        Member member = findMember(user.getUserId());
+        Member member = findMemberByUserId(user.getUserId());
 
         checkPassword(request.getOldPassword(), member);
 
@@ -222,7 +222,7 @@ public class MemberService {
 
     @Transactional
     public String deleteMember(AuthenticateUser user) {
-        Member member = findMember(user.getUserId());
+        Member member = findMemberByUserId(user.getUserId());
         memberRepository.delete(member);
         return "회원이 삭제되었습니다.";
     }
@@ -250,19 +250,24 @@ public class MemberService {
 
     @Transactional
     public String enableAiComment(AuthenticateUser user) {
-        Member member = findMember(user.getUserId());
+        Member member = findMemberByUserId(user.getUserId());
         member.enableAiComment();
         return "AI 댓글 기능이 활성화되었습니다.";
     }
 
     @Transactional
     public String disableAiComment(AuthenticateUser user) {
-        Member member = findMember(user.getUserId());
+        Member member = findMemberByUserId(user.getUserId());
         member.disableAiComment();
         return "AI 댓글 기능이 비활성화되었습니다.";
     }
 
-    private Member findMember(String userId) {
+    public Member findMemberById(Long id) {
+        return memberRepository.findById(id)
+                .orElseThrow(() -> new UnauthorizedException("멤버가 존재하지 않습니다."));
+    }
+
+    public Member findMemberByUserId(String userId) {
         return memberRepository.findByUserId(userId)
                 .orElseThrow(() -> new UnauthorizedException("멤버가 존재하지 않습니다."));
     }

--- a/src/main/java/com/gdg/Todak/point/scheduler/PointReconciliationScheduler.java
+++ b/src/main/java/com/gdg/Todak/point/scheduler/PointReconciliationScheduler.java
@@ -2,8 +2,7 @@ package com.gdg.Todak.point.scheduler;
 
 import com.gdg.Todak.common.lock.LockExecutor;
 import com.gdg.Todak.member.domain.Member;
-import com.gdg.Todak.member.exception.UnauthorizedException;
-import com.gdg.Todak.member.repository.MemberRepository;
+import com.gdg.Todak.member.service.MemberService;
 import com.gdg.Todak.point.service.PointReconciliationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,7 +22,7 @@ public class PointReconciliationScheduler {
 
     private final LockExecutor lockExecutor;
     private final PointReconciliationService pointReconciliationService;
-    private final MemberRepository memberRepository;
+    private final MemberService memberService;
 
     @Scheduled(cron = "0 0 4 * * *")
     public void reconcilePoints() {
@@ -39,7 +38,7 @@ public class PointReconciliationScheduler {
     }
 
     private void reconcilePointWithLock(Long memberId) {
-        Member member = findMember(memberId);
+        Member member = memberService.findMemberById(memberId);
         lockExecutor.executeWithLock(
                 LOCK_PREFIX,
                 member,
@@ -53,10 +52,5 @@ public class PointReconciliationScheduler {
         } catch (Exception e) {
             log.error("포인트 보정 중 오류 발생 | Member ID: {}", memberId, e);
         }
-    }
-
-    private Member findMember(Long memberId) {
-        return memberRepository.findById(memberId)
-                .orElseThrow(() -> new UnauthorizedException("멤버가 존재하지 않습니다."));
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #-


## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.(이미지 첨부 가능)

**Member 조회 책임 분리 및 포인트 정합성 작업 트랜잭션 효율화**
* 멤버 조회 및 예외 처리를 전용 MemberService로 분리하여 여러 곳에서 재사용할 수 있도록 개선하였습니다.
* 스케줄러에서 멤버 조회 시, 짧은 트랜잭션(readOnly)으로 멤버 검증 후 분산 락 및 포인트 정합성 보정 로직이 실행되도록 구조를 최적화하였습니다.
* 이로써 트랜잭션 점유를 최소화하고, 전체적인 리소스 사용 효율과 성능이 향상되었습니다.

### 스크린샷 (선택)
-

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> -


## ⏰ 현재 버그
-

## ✏ Git Close
> close #-
