### PR TITLE
refactor: 알림 저장 비동기화

### DIFF
--- a/src/main/java/com/gdg/Todak/common/config/AsyncConfig.java
+++ b/src/main/java/com/gdg/Todak/common/config/AsyncConfig.java
@@ -23,4 +23,16 @@ public class AsyncConfig {
         executor.initialize();
         return executor;
     }
+
+    @Bean(name = "steadyExecutor")
+    public Executor steadyExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(50);      // 높은 기본 스레드 수로 일정한 처리량 유지
+        executor.setMaxPoolSize(60);       // 약간의 여유만 두기
+        executor.setQueueCapacity(500);    // 큰 대기열로 일시적 부하 흡수
+        executor.setThreadNamePrefix("Steady-");
+        executor.setKeepAliveSeconds(60);  // 추가 스레드의 유휴 시간 제한
+        executor.initialize();
+        return executor;
+    }
 }

--- a/src/main/java/com/gdg/Todak/event/listener/NewCommentNotificationListener.java
+++ b/src/main/java/com/gdg/Todak/event/listener/NewCommentNotificationListener.java
@@ -3,6 +3,7 @@ package com.gdg.Todak.event.listener;
 import com.gdg.Todak.diary.entity.Comment;
 import com.gdg.Todak.event.event.NewCommentEvent;
 import com.gdg.Todak.notification.dto.PublishNotificationRequest;
+import com.gdg.Todak.notification.facade.NotificationFacade;
 import com.gdg.Todak.notification.service.NotificationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
@@ -16,7 +17,7 @@ import java.time.Instant;
 @RequiredArgsConstructor
 public class NewCommentNotificationListener {
 
-    private final NotificationService notificationService;
+    private final NotificationFacade notificationFacade;
 
     @Async
     @EventListener
@@ -29,6 +30,6 @@ public class NewCommentNotificationListener {
 
         PublishNotificationRequest request = PublishNotificationRequest.of(senderId, receiverId, "comment", diaryId, createdAt);
 
-        notificationService.publishNotification(request);
+        notificationFacade.publishNotification(request);
     }
 }

--- a/src/main/java/com/gdg/Todak/event/listener/NewDiaryNotificationListener.java
+++ b/src/main/java/com/gdg/Todak/event/listener/NewDiaryNotificationListener.java
@@ -6,6 +6,7 @@ import com.gdg.Todak.friend.FriendStatus;
 import com.gdg.Todak.friend.entity.Friend;
 import com.gdg.Todak.friend.repository.FriendRepository;
 import com.gdg.Todak.notification.dto.PublishNotificationRequest;
+import com.gdg.Todak.notification.facade.NotificationFacade;
 import com.gdg.Todak.notification.service.NotificationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
@@ -18,7 +19,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class NewDiaryNotificationListener {
 
-    private final NotificationService notificationService;
+    private final NotificationFacade notificationFacade;
     private final FriendRepository friendRepository;
 
     @Async
@@ -35,7 +36,7 @@ public class NewDiaryNotificationListener {
         for (Friend friend : friends) {
             String receiverId = friend.getFriend(senderId).getUserId();
             PublishNotificationRequest request = PublishNotificationRequest.of(senderId, receiverId, "diary", diary.getId(), diary.getCreatedAt());
-            notificationService.publishNotification(request);
+            notificationFacade.publishNotification(request);
         }
     }
 }

--- a/src/main/java/com/gdg/Todak/event/listener/NewFriendRequestNotificationListener.java
+++ b/src/main/java/com/gdg/Todak/event/listener/NewFriendRequestNotificationListener.java
@@ -3,6 +3,7 @@ package com.gdg.Todak.event.listener;
 import com.gdg.Todak.event.event.NewFriendRequestEvent;
 import com.gdg.Todak.friend.entity.Friend;
 import com.gdg.Todak.notification.dto.PublishNotificationRequest;
+import com.gdg.Todak.notification.facade.NotificationFacade;
 import com.gdg.Todak.notification.service.NotificationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
@@ -15,7 +16,7 @@ import java.time.Instant;
 @RequiredArgsConstructor
 public class NewFriendRequestNotificationListener {
 
-    private final NotificationService notificationService;
+    private final NotificationFacade notificationFacade;
 
     @Async
     @EventListener
@@ -26,6 +27,6 @@ public class NewFriendRequestNotificationListener {
 
         PublishNotificationRequest request = PublishNotificationRequest.of(senderId, receiverId, "friend", null, Instant.now());
 
-        notificationService.publishNotification(request);
+        notificationFacade.publishNotification(request);
     }
 }

--- a/src/main/java/com/gdg/Todak/notification/controller/dto/AckRequest.java
+++ b/src/main/java/com/gdg/Todak/notification/controller/dto/AckRequest.java
@@ -7,5 +7,5 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class AckRequest {
 
-    private String notificationId;
+    private Long notificationId;
 }

--- a/src/main/java/com/gdg/Todak/notification/entity/Notification.java
+++ b/src/main/java/com/gdg/Todak/notification/entity/Notification.java
@@ -1,5 +1,6 @@
 package com.gdg.Todak.notification.entity;
 
+import com.gdg.Todak.notification.dto.PublishNotificationRequest;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,22 +12,38 @@ import java.time.Instant;
 @ToString
 @NoArgsConstructor
 public class Notification {
-    private String id;
+    private Long id;
     private Long objectId;
     private String senderUserId;
     private String receiverUserId;
     private String type;
-    private Instant diaryCreatedAt;
     private Instant createdAt;
 
     @Builder
-    public Notification(String id, Long objectId, String senderUserId, String receiverUserId, String type, Instant diaryCreatedAt, Instant createdAt) {
-        this.id = id;
+    public Notification(Long objectId, String senderUserId, String receiverUserId, String type, Instant createdAt) {
         this.objectId = objectId;
         this.senderUserId = senderUserId;
         this.receiverUserId = receiverUserId;
         this.type = type;
-        this.diaryCreatedAt = diaryCreatedAt;
         this.createdAt = createdAt;
+    }
+
+    public static Notification from(PublishNotificationRequest request) {
+        return Notification.builder()
+                .objectId(request.getObjectId())
+                .senderUserId(request.getSenderId())
+                .receiverUserId(request.getReceiverId())
+                .type(request.getType())
+                .createdAt(request.getCreatedAt())
+                .build();
+    }
+
+    public static void checkNotificationSenderAndReceiver(PublishNotificationRequest request) {
+        String senderId = request.getSenderId();
+        String receiverId = request.getReceiverId();
+
+        if (senderId == receiverId) {
+            throw new RuntimeException("Sender and Receiver can't be same");
+        }
     }
 }

--- a/src/main/java/com/gdg/Todak/notification/facade/NotificationFacade.java
+++ b/src/main/java/com/gdg/Todak/notification/facade/NotificationFacade.java
@@ -1,0 +1,22 @@
+package com.gdg.Todak.notification.facade;
+
+import com.gdg.Todak.notification.dto.PublishNotificationRequest;
+import com.gdg.Todak.notification.entity.Notification;
+import com.gdg.Todak.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationFacade {
+
+    private final NotificationService notificationService;
+
+    public void publishNotification(PublishNotificationRequest request) {
+        Notification.checkNotificationSenderAndReceiver(request);
+
+        notificationService.saveNotification(request);
+
+        notificationService.publishEventToRedis(Notification.from(request));
+    }
+}

--- a/src/main/java/com/gdg/Todak/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/gdg/Todak/notification/repository/NotificationRepository.java
@@ -1,0 +1,12 @@
+package com.gdg.Todak.notification.repository;
+
+import com.gdg.Todak.notification.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+    List<Notification> findAllByReceiverId(String receiverId);
+}

--- a/src/main/java/com/gdg/Todak/notification/service/NotificationService.java
+++ b/src/main/java/com/gdg/Todak/notification/service/NotificationService.java
@@ -74,7 +74,7 @@ public class NotificationService {
         });
     }
 
-    @Async
+    @Async(value = "steadyExecutor")
     @Transactional
     public void saveNotification(PublishNotificationRequest request) {
         Notification notification = Notification.from(request);

--- a/src/main/java/com/gdg/Todak/study/service/StudyService.java
+++ b/src/main/java/com/gdg/Todak/study/service/StudyService.java
@@ -12,6 +12,7 @@ import com.gdg.Todak.friend.repository.FriendRepository;
 import com.gdg.Todak.member.domain.Member;
 import com.gdg.Todak.member.service.MemberService;
 import com.gdg.Todak.notification.dto.PublishNotificationRequest;
+import com.gdg.Todak.notification.facade.NotificationFacade;
 import com.gdg.Todak.notification.service.NotificationService;
 import com.gdg.Todak.point.PointStatus;
 import com.gdg.Todak.point.PointType;
@@ -59,7 +60,7 @@ public class StudyService {
 
     private final MemberService memberService;
     private final DiaryRepository diaryRepository;
-    private final NotificationService notificationService;
+    private final NotificationFacade notificationFacade;
     private final FriendRepository friendRepository;
     private final SchedulerService schedulerService;
     private final PointRepository pointRepository;
@@ -99,7 +100,7 @@ public class StudyService {
         for (Friend friend : friends) {
             String receiverId = friend.getFriend(senderId).getUserId();
             PublishNotificationRequest request = PublishNotificationRequest.of(senderId, receiverId, "diary", diary.getId(), diary.getCreatedAt());
-            notificationService.publishNotification(request);
+            notificationFacade.publishNotification(request);
         }
 
         schedulerService.scheduleSavingCommentByAI(diary);


### PR DESCRIPTION
## #️⃣ 연관된 이슈
x


## 📝 작업 내용
- 오프라인 상태의 유저들 알림 저장 프로세스 비동기화
- facade 계층을 도입하여 비동기 처리
- dead sseEmitter 삭제 로직 수정
- steady executor 스레드 설정 추가

### 스크린샷 (선택)
x

## 💬 리뷰 요구사항(선택)
x


## ⏰ 현재 버그
x

## ✏ Git Close
x
